### PR TITLE
Update for osx development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 [Oo]utput/
 [Rr]elease/[Mm]odels/
 [Rr]elease/[Ss]ample_[Ii]mages/
+release/.DS_Store

--- a/release/env_cpu.yml
+++ b/release/env_cpu.yml
@@ -9,9 +9,9 @@ dependencies:
   - pip
   - python
   - requests
-  - tensorflow=2.1.0
   - pip:
       - opencv-python==4.2.0.*
       - pyqt5
+      - tensorflow=2.1.0
 prefix: ./env/stefann-cpu
 

--- a/release/env_cpu.yml
+++ b/release/env_cpu.yml
@@ -9,10 +9,8 @@ dependencies:
   - pip
   - python
   - requests
+  - tensorflow=2.1.0
   - pip:
-      - opencv-python==4.1.0.*
+      - opencv-python==4.2.0.*
       - pyqt5
-      - opencv-contrib-python-headless
-      - tensorflow==2.1.0
 prefix: ./env/stefann-cpu
-

--- a/release/env_cpu.yml
+++ b/release/env_cpu.yml
@@ -10,8 +10,9 @@ dependencies:
   - python
   - requests
   - pip:
-      - opencv-python==4.2.0.*
+      - opencv-python==4.1.0.*
       - pyqt5
-      - tensorflow=2.1.0
+      - opencv-contrib-python-headless
+      - tensorflow==2.1.0
 prefix: ./env/stefann-cpu
 

--- a/release/env_osx.yml
+++ b/release/env_osx.yml
@@ -1,0 +1,17 @@
+name: stefann-osx
+channels:
+  - defaults
+dependencies:
+  - colorama
+  - keras
+  - numpy
+  - pillow
+  - pip
+  - python
+  - requests
+  - pip:
+      - opencv-python==4.1.0.*
+      - opencv-contrib-python-headless
+      - pyqt5
+      - tensorflow==2.1.0
+prefix: ./env/stefann-osx


### PR DESCRIPTION
Hi, I did some updates to the cpu dependencies because I found something that was blocking the execution on osx catalina.

As you can see I moved tensorflow to pip because conda was throwing an error.
For the same reason I've downgraded opencv to version 4.1.x.

Due to a conflict with Cocoa libs on mac, I forced the use of pyqt5 by adding the opencv-contrib-python-headless.

After this, everything is working fine as expected.
